### PR TITLE
http: use closeWrapper instead of releaseWrapper

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -117,6 +117,13 @@ func (c *Conn) Release(err interface{}, score float64) error {
 	return h.releaseConn(c, e, score)
 }
 
+// Close the connection
+func (c *Conn) Close() error {
+	h := c.host
+	c.host = nil
+	return h.pool.CloseConn(c)
+}
+
 // Address returns the address of the host bound to the connection.
 func (c *Conn) Address() string {
 	if c.host == nil {

--- a/http.go
+++ b/http.go
@@ -12,7 +12,7 @@ func NewHTTPTransport(service *Service) *http.Transport {
 			return nil, err
 		}
 
-		w := &releaseWrapper{
+		w := &closeWrapper{
 			Conn: c.NetConn(),
 			conn: c,
 		}

--- a/pool.go
+++ b/pool.go
@@ -264,6 +264,12 @@ func (p *Pool) Put(c *Conn, e error) (bool, error) {
 	return false, nil
 }
 
+// CloseConn garbage collects a given connection
+func (p *Pool) CloseConn(c *Conn) error {
+	p.gc <- c
+	return nil
+}
+
 // Close closes the pool, thus destroying all connections.
 // It returns when all spawned connections have been successfully garbage collected.
 // After a successful call to Close, the pool can not be used again.

--- a/wrapper.go
+++ b/wrapper.go
@@ -53,3 +53,30 @@ func (w *releaseWrapper) Write(b []byte) (n int, err error) {
 func (w *releaseWrapper) Close() error {
 	return w.conn.Release(w.lasterr.Load(), HostUp)
 }
+
+type closeWrapper struct {
+	net.Conn
+
+	conn    *Conn
+	lasterr atomic.Value
+}
+
+func (w *closeWrapper) Read(b []byte) (n int, err error) {
+	n, err = w.Conn.Read(b)
+	if err != nil {
+		w.lasterr.Store(&err)
+	}
+	return
+}
+
+func (w *closeWrapper) Write(b []byte) (n int, err error) {
+	n, err = w.Conn.Write(b)
+	if err != nil {
+		w.lasterr.Store(&err)
+	}
+	return
+}
+
+func (w *closeWrapper) Close() error {
+	return w.conn.Close()
+}


### PR DESCRIPTION
Pooly opens HTTP connections with keep-alive disabled,
but tries to reuse open connections after an HTTP response
has been received. This lead the HTTP server to reset
the TCP connection.

This change implements a closeWrapper, analog to releaseWrapper.
However, closeWrapper closes the TCP connection, instead of
putting it back to the connection pool. Now, NewHTTPTransport
can use closeWrapper instead of releaseWrapper.
