### PR TITLE
service: append the name of the service in the error returned by GetConn

### DIFF
--- a/service.go
+++ b/service.go
@@ -1,6 +1,7 @@
 package pooly
 
 import (
+	"fmt"
 	"github.com/cactus/go-statsd-client/statsd"
 	"log"
 	"runtime"
@@ -272,7 +273,7 @@ again:
 			attempts++
 			goto again
 		}
-		return nil, err
+		return nil, fmt.Errorf("%s: %v", s.name, err)
 	}
 
 	// Send statsd metrics


### PR DESCRIPTION
It may be useful to know the name of the service
when an error is reported by GetConn.